### PR TITLE
Fix flaky test UndertowSubsystem30TestCase#testRuntime

### DIFF
--- a/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-
+import java.util.List;
 import javax.net.ssl.SSLContext;
 
 import io.undertow.predicate.Predicates;
@@ -70,6 +70,7 @@ import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.Xnio;
 import org.xnio.XnioWorker;
+import static org.hamcrest.CoreMatchers.*;
 
 public abstract class AbstractUndertowSubsystemTestCase extends AbstractSubsystemBaseTest {
     public AbstractUndertowSubsystemTestCase() {
@@ -129,7 +130,9 @@ public abstract class AbstractUndertowSubsystemTestCase extends AbstractSubsyste
         Host host = (Host) awaitServiceValue(hostSC);
         if (flag == 1) {
             Assert.assertEquals(3, host.getAllAliases().size());
-            Assert.assertEquals("default-alias", new ArrayList<>(host.getAllAliases()).get(1));
+            List<String> aliasesList = new ArrayList<>(host.getAllAliases());
+            aliasesList.sort(String::compareToIgnoreCase);
+            Assert.assertEquals("default-alias", aliasesList.get(0));
         }
 
         final ServiceName locationServiceName = UndertowService.locationServiceName(virtualHostName, "default-virtual-host", "/");

--- a/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
@@ -23,12 +23,12 @@ package org.wildfly.extension.undertow;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import java.util.List;
 import javax.net.ssl.SSLContext;
 
 import io.undertow.predicate.Predicates;
@@ -70,7 +70,6 @@ import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.Xnio;
 import org.xnio.XnioWorker;
-import static org.hamcrest.CoreMatchers.*;
 
 public abstract class AbstractUndertowSubsystemTestCase extends AbstractSubsystemBaseTest {
     public AbstractUndertowSubsystemTestCase() {

--- a/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+
 import javax.net.ssl.SSLContext;
 
 import io.undertow.predicate.Predicates;


### PR DESCRIPTION
The test `UndertowSubsystem30TestCase#testRuntime` compares the result of `host.getAllAliases()` to a hard-coded string based on a specific order of entries in `HashMap`. However, these classes do not guarantee that order, and the assertion can fail if the order differs.

The PR sort the result from `host.getAllAliases()` to make the order deterministic.
